### PR TITLE
Output-format-and-ignore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/demisto/thirdPartyLicenseCollector
+module github.com/aviadl/thirdPartyLicenseCollector
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -5,17 +5,18 @@ import (
 	"log"
 	"os"
 
-	licensecollector "github.com/demisto/thirdPartyLicenseCollector/license-collector"
+	licensecollector "github.com/aviadl/thirdPartyLicenseCollector/license-collector"
 )
 
 func main() {
 	tmpGoDir := flag.String("go-project", "", "project directory")
 	tmpNpmDir := flag.String("npm-project", "", "npm directory")
 	out := flag.String("out", licensecollector.LicenseFileName, "output file")
+	format := flag.String("format", licensecollector.DefaultLicenseFileFormat, "output format: text vs json")
 	flag.Parse()
 	log.SetFlags(0)
 
-	err := licensecollector.Collect(*tmpGoDir, *tmpNpmDir, *out)
+	err := licensecollector.Collect(*tmpGoDir, *tmpNpmDir, *out, *format)
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Support the `ignore` keyword in manual license file
add options of how license file will be generated