### PR TITLE
support npm node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 *.prof
 
 # Created by .ignore support plugin (hsz.mobi)
+
+# Auto generated files
+THIRD_PARTY_LICENSE

--- a/license-collector/LicenseCollector.go
+++ b/license-collector/LicenseCollector.go
@@ -14,16 +14,16 @@ import (
 	"github.com/ryanuber/go-license"
 )
 
-//LicenseFileName is the default created license file name
+// LicenseFileName is the default created license file name
 const LicenseFileName = "THIRD_PARTY_LICENSE"
 const DefaultLicenseFileFormat = "txt"
 const vendorGoModuleFile = "modules.txt"
 
-//licenseMissing indicates that a license is missing
+// licenseMissing indicates that a license is missing
 var licenseMissing = false
 
-//Collect collects licenses from npm and or go projects
-func Collect(projectGO, projectNPM string, fileName string, fileFormat string) error {
+// Collect collects licenses from npm and or go projects
+func Collect(projectGO, projectNPM string, projectNodeModules string, fileName string, fileFormat string) error {
 	licenseMap := map[string][]string{}
 	foundManualLicense := map[string]string{}
 
@@ -33,7 +33,7 @@ func Collect(projectGO, projectNPM string, fileName string, fileFormat string) e
 		err = collectGoLicenseFiles(projectGO, licenseMap, foundManualLicense)
 	}
 	if len(projectNPM) > 0 {
-		err = collectNpmLicenseFiles(projectNPM, licenseMap, foundManualLicense)
+		err = collectNpmLicenseFiles(projectNPM, projectNodeModules, licenseMap, foundManualLicense)
 	}
 	if err != nil {
 		return err
@@ -97,9 +97,13 @@ func collectGoLicenseFiles(tmpGoDir string, licenseMap map[string][]string, foun
 	return nil
 }
 
-func collectNpmLicenseFiles(tmpNpmDir string, licenseMap map[string][]string, foundManualLicense map[string]string) error {
+func collectNpmLicenseFiles(tmpNpmDir string, tmpNodeModulesDir string, licenseMap map[string][]string, foundManualLicense map[string]string) error {
 	log.Println("NPM Project dir: ", tmpNpmDir)
-	dir := filepath.Join(tmpNpmDir, "node_modules")
+	nodeModulesDir := tmpNpmDir
+	if len(tmpNodeModulesDir) > 0 {
+		nodeModulesDir = tmpNodeModulesDir
+	}
+	dir := filepath.Join(nodeModulesDir, "node_modules")
 	fileName := filepath.Join(tmpNpmDir, "package.json")
 	log.Println("Processing package file: ", fileName)
 	data, err := ioutil.ReadFile(fileName)
@@ -262,7 +266,7 @@ func prepareManualLicense(vendorDir string) (map[string]string, error) {
 	return licenseMap, err
 }
 
-//parseLicenseManual will look for the manual license file index, to add files that cannot be found automatically
+// parseLicenseManual will look for the manual license file index, to add files that cannot be found automatically
 func parseLicenseManual(dir string, manualFileMap map[string]string) (lDir string, lContent string, missing bool) {
 	dirs := strings.Split(dir, "/")
 	currentDir := ""

--- a/main.go
+++ b/main.go
@@ -11,12 +11,14 @@ import (
 func main() {
 	tmpGoDir := flag.String("go-project", "", "project directory")
 	tmpNpmDir := flag.String("npm-project", "", "npm directory")
+	// For some project - the node modules are not in the same directory as the package.json
+	tmpNodeModulesDir := flag.String("npm-node-modules", "", "node_modules directory (optional, leave empty if it is in the same as npm-project)")
 	out := flag.String("out", licensecollector.LicenseFileName, "output file")
 	format := flag.String("format", licensecollector.DefaultLicenseFileFormat, "output format: text vs json")
 	flag.Parse()
 	log.SetFlags(0)
 
-	err := licensecollector.Collect(*tmpGoDir, *tmpNpmDir, *out, *format)
+	err := licensecollector.Collect(*tmpGoDir, *tmpNpmDir, *tmpNodeModulesDir, *out, *format)
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
For some projects (angular workspace with multiple projects for example) - the node modules are not in the same directory as the package.json

supported for `npm-node-modules` flag to be able to configure it 